### PR TITLE
Just icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,26 +29,27 @@ function App() {
 
 ## 🔧 Props
 
-| Prop                 | Type                    | Default        | Description                          |
-| -------------------- | ----------------------- | -------------- | ------------------------------------ |
-| value                | string                  | ""             | Text to display and edit             |
-| isEditing            | boolean                 | false          | Initial editing state                |
-| inputType            | string                  | "text"         | Type of input field                  |
-| label                | string                  | ""             | Label for the input                  |
-| className            | string                  | ""             | Container class name                 |
-| inputClassName       | string                  | ""             | Input field class name               |
-| editButtonClassName  | string                  | ""             | Edit button class name               |
-| saveButtonClassName  | string                  | ""             | Save button class name               |
-| editWrapperClassName | string                  | ""             | Edit mode wrapper class name         |
-| saveButtonLabel      | React.ReactNode         | "Save"         | Custom save button label             |
-| editButtonLabel      | React.ReactNode         | "Edit"         | Custom edit button label             |
-| showIcons            | boolean                 | false          | Show icons in buttons                |
-| editIcon             | React.ReactNode         | `<LuPencil />` | Custom edit icon                     |
-| saveIcon             | React.ReactNode         | `<LuCheck />`  | Custom save icon                     |
-| iconPosition         | "left" \| "right"       | "left"         | Position of icons in buttons         |
-| onEditButtonClick    | () => void              | () => {}       | Callback when edit button is clicked |
-| onInputChange        | (value: string) => void | () => {}       | Callback when input value changes    |
-| onSaveButtonClick    | () => void              | () => {}       | Callback when save button is clicked |
+| Prop                 | Type                    | Default        | Description                           |
+| -------------------- | ----------------------- | -------------- | ------------------------------------- |
+| value                | string                  | ""             | Text to display and edit              |
+| isEditing            | boolean                 | false          | Initial editing state                 |
+| inputType            | string                  | "text"         | Type of input field                   |
+| label                | string                  | ""             | Label for the input                   |
+| className            | string                  | ""             | Container class name                  |
+| inputClassName       | string                  | ""             | Input field class name                |
+| editButtonClassName  | string                  | ""             | Edit button class name                |
+| saveButtonClassName  | string                  | ""             | Save button class name                |
+| editWrapperClassName | string                  | ""             | Edit mode wrapper class name          |
+| saveButtonLabel      | React.ReactNode         | "Save"         | Custom save button label              |
+| editButtonLabel      | React.ReactNode         | "Edit"         | Custom edit button label              |
+| showIcons            | boolean                 | false          | Show icons in buttons                 |
+| editIcon             | React.ReactNode         | `<LuPencil />` | Custom edit icon                      |
+| saveIcon             | React.ReactNode         | `<LuCheck />`  | Custom save icon                      |
+| iconPosition         | "left" \| "right"       | "left"         | Position of icons in buttons          |
+| onEditButtonClick    | () => void              | () => {}       | Callback when edit button is clicked  |
+| onInputChange        | (value: string) => void | () => {}       | Callback when input value changes     |
+| onSaveButtonClick    | () => void              | () => {}       | Callback when save button is clicked  |
+| justIcons            | boolean                 | false          | Show only icons without button labels |
 
 ## 💡 Examples
 
@@ -78,6 +79,17 @@ function App() {
   showIcons
   editIcon={<span>✍️</span>}
   saveIcon={<span>👍</span>}
+/>
+```
+
+### Icons Only (No Text Labels)
+
+```tsx
+<InputClickEdit
+  value="Icons only buttons"
+  justIcons
+  editIcon={<span>✎</span>}
+  saveIcon={<span>✓</span>}
 />
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ function App() {
 | onEditButtonClick    | () => void              | () => {}       | Callback when edit button is clicked  |
 | onInputChange        | (value: string) => void | () => {}       | Callback when input value changes     |
 | onSaveButtonClick    | () => void              | () => {}       | Callback when save button is clicked  |
-| justIcons            | boolean                 | false          | Show only icons without button labels |
+| iconsOnly            | boolean                 | false          | Show only icons without button labels |
 
 ## 💡 Examples
 
@@ -87,7 +87,7 @@ function App() {
 ```tsx
 <InputClickEdit
   value="Icons only buttons"
-  justIcons
+  iconsOnly
   editIcon={<span>✎</span>}
   saveIcon={<span>✓</span>}
 />

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -23,7 +23,7 @@ function App() {
       <div className="card">
         <InputClickEdit onInputChange={handleChange} value={value} showIcons />
         <br />
-        <InputClickEdit onInputChange={handleChange} value={value} iconsOnly />
+        <InputClickEdit onInputChange={handleChange} value={value} justIcons />
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -23,7 +23,7 @@ function App() {
       <div className="card">
         <InputClickEdit onInputChange={handleChange} value={value} showIcons />
         <br />
-        <InputClickEdit onInputChange={handleChange} value={value} justIcons />
+        <InputClickEdit onInputChange={handleChange} value={value} iconsOnly />
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -22,6 +22,8 @@ function App() {
       <h1>Vite + React</h1>
       <div className="card">
         <InputClickEdit onInputChange={handleChange} value={value} showIcons />
+        <br />
+        <InputClickEdit onInputChange={handleChange} value={value} justIcons />
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>

--- a/src/InputClickEdit/InputClickEdit.tsx
+++ b/src/InputClickEdit/InputClickEdit.tsx
@@ -89,6 +89,7 @@ const InputClickEdit = ({
           <button
             className={cn(buttonBaseClassName, saveButtonClassName)}
             onClick={handleSave}
+            aria-label={iconsOnly ? saveButtonLabel?.toString() : undefined}
           >
             {(showIcons || iconsOnly) && saveIcon}
             {!iconsOnly && saveButtonLabel}
@@ -100,6 +101,7 @@ const InputClickEdit = ({
           <button
             className={cn(buttonBaseClassName, editButtonClassName)}
             onClick={onEditClick}
+            aria-label={iconsOnly ? editButtonLabel?.toString() : undefined}
           >
             {(showIcons || iconsOnly) && editIcon}
             {!iconsOnly && editButtonLabel}

--- a/src/InputClickEdit/InputClickEdit.tsx
+++ b/src/InputClickEdit/InputClickEdit.tsx
@@ -73,7 +73,6 @@ const InputClickEdit = ({
     [styles.button]: true,
     [styles.buttonReverse]: iconPosition === "right",
   };
-  const displayIcons = showIcons || iconsOnly;
 
   return (
     <div className={cn(styles.wrapper, className)}>
@@ -91,7 +90,7 @@ const InputClickEdit = ({
             className={cn(buttonBaseClassName, saveButtonClassName)}
             onClick={handleSave}
           >
-            {displayIcons && saveIcon}
+            {(showIcons || iconsOnly) && saveIcon}
             {!iconsOnly && saveButtonLabel}
           </button>
         </div>
@@ -102,7 +101,7 @@ const InputClickEdit = ({
             className={cn(buttonBaseClassName, editButtonClassName)}
             onClick={onEditClick}
           >
-            {displayIcons && editIcon}
+            {(showIcons || iconsOnly) && editIcon}
             {!iconsOnly && editButtonLabel}
           </button>
         </div>

--- a/src/InputClickEdit/InputClickEdit.tsx
+++ b/src/InputClickEdit/InputClickEdit.tsx
@@ -21,7 +21,7 @@ type InputClickEditProps = {
   editIcon?: React.ReactNode;
   saveIcon?: React.ReactNode;
   iconPosition?: "left" | "right";
-  justIcons?: boolean;
+  iconsOnly?: boolean;
   onEditButtonClick?: () => void;
   onInputChange?: (value: string) => void;
   onSaveButtonClick?: () => void;
@@ -42,7 +42,7 @@ const InputClickEdit = ({
   showIcons = false,
   saveIcon = <LuCheck />,
   editIcon = <LuPencil />,
-  justIcons = false,
+  iconsOnly = false,
   iconPosition = "left",
   onEditButtonClick = () => {},
   onInputChange = () => {},
@@ -73,7 +73,7 @@ const InputClickEdit = ({
     [styles.button]: true,
     [styles.buttonReverse]: iconPosition === "right",
   };
-  const displayIcons = showIcons || justIcons;
+  const displayIcons = showIcons || iconsOnly;
 
   return (
     <div className={cn(styles.wrapper, className)}>
@@ -92,7 +92,7 @@ const InputClickEdit = ({
             onClick={handleSave}
           >
             {displayIcons && saveIcon}
-            {!justIcons && saveButtonLabel}
+            {!iconsOnly && saveButtonLabel}
           </button>
         </div>
       ) : (
@@ -103,7 +103,7 @@ const InputClickEdit = ({
             onClick={onEditClick}
           >
             {displayIcons && editIcon}
-            {!justIcons && editButtonLabel}
+            {!iconsOnly && editButtonLabel}
           </button>
         </div>
       )}

--- a/src/InputClickEdit/InputClickEdit.tsx
+++ b/src/InputClickEdit/InputClickEdit.tsx
@@ -21,6 +21,7 @@ type InputClickEditProps = {
   editIcon?: React.ReactNode;
   saveIcon?: React.ReactNode;
   iconPosition?: "left" | "right";
+  justIcons?: boolean;
   onEditButtonClick?: () => void;
   onInputChange?: (value: string) => void;
   onSaveButtonClick?: () => void;
@@ -41,6 +42,7 @@ const InputClickEdit = ({
   showIcons = false,
   saveIcon = <LuCheck />,
   editIcon = <LuPencil />,
+  justIcons = false,
   iconPosition = "left",
   onEditButtonClick = () => {},
   onInputChange = () => {},
@@ -71,6 +73,7 @@ const InputClickEdit = ({
     [styles.button]: true,
     [styles.buttonReverse]: iconPosition === "right",
   };
+  const displayIcons = showIcons || justIcons;
 
   return (
     <div className={cn(styles.wrapper, className)}>
@@ -88,8 +91,8 @@ const InputClickEdit = ({
             className={cn(buttonBaseClassName, saveButtonClassName)}
             onClick={handleSave}
           >
-            {showIcons && saveIcon}
-            {saveButtonLabel}
+            {displayIcons && saveIcon}
+            {!justIcons && saveButtonLabel}
           </button>
         </div>
       ) : (
@@ -99,8 +102,8 @@ const InputClickEdit = ({
             className={cn(buttonBaseClassName, editButtonClassName)}
             onClick={onEditClick}
           >
-            {showIcons && editIcon}
-            {editButtonLabel}
+            {displayIcons && editIcon}
+            {!justIcons && editButtonLabel}
           </button>
         </div>
       )}


### PR DESCRIPTION
This PR adds the feature of just display the icon on the buttons of the component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added `iconsOnly` prop to `InputClickEdit` component, allowing optional icon-only button display.
  - Introduced flexible button rendering with the option to show icons without text labels.

- **Documentation**
  - Updated README with new `iconsOnly` property and example usage.
  - Added visual example demonstrating icon-only button configuration.

- **Examples**
  - Included new `InputClickEdit` component instance in App showcasing icon-only mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->