### PR TITLE
Uncontrolled and controlled input

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,26 +44,26 @@ function App() {
 
 ## 🔧 Props
 
-| Prop              | Type                                 | Default  | Description                               |
-| ----------------- | ------------------------------------ | -------- | ----------------------------------------- |
-| value             | string                               | -        | Controlled text value to display and edit |
-| defaultValue      | string                               | -        | Initial uncontrolled value                |
-| type              | string                               | "text"   | HTML input type attribute                 |
-| onChange          | ChangeEventHandler<HTMLInputElement> | -        | HTML input onChange handler               |
-| isEditing         | boolean                              | false    | Control the editing state                 |
-| label             | string                               | ""       | Label for the input field                 |
-| className         | string                               | ""       | Container class name                      |
-| editButtonLabel   | React.ReactNode                      | "Edit"   | Custom edit button label                  |
-| saveButtonLabel   | React.ReactNode                      | "Save"   | Custom save button label                  |
-| showIcons         | boolean                              | false    | Toggle button icons visibility            |
-| iconsOnly         | boolean                              | false    | Show only icons without text labels       |
-| editIcon          | React.ElementType                    | LuPencil | Custom edit icon component                |
-| saveIcon          | React.ElementType                    | LuCheck  | Custom save icon component                |
-| iconPosition      | "left" \| "right"                    | "left"   | Position of icons in buttons              |
-| onEditButtonClick | () => void                           | () => {} | Callback when edit button is clicked      |
-| onSaveButtonClick | () => void                           | () => {} | Callback when save button is clicked      |
+| Prop              | Type                                 | Required | Default  | Description                               |
+| ----------------- | ------------------------------------ | -------- | -------- | ----------------------------------------- |
+| value             | string                               | Yes\*    | -        | Controlled text value to display and edit |
+| defaultValue      | string                               | No       | -        | Initial uncontrolled value                |
+| type              | string                               | No       | "text"   | HTML input type attribute                 |
+| onChange          | ChangeEventHandler<HTMLInputElement> | Yes\*    | -        | HTML input onChange handler               |
+| isEditing         | boolean                              | No       | false    | Control the editing state                 |
+| label             | string                               | No       | ""       | Label for the input field                 |
+| className         | string                               | No       | ""       | Container class name                      |
+| editButtonLabel   | React.ReactNode                      | No       | "Edit"   | Custom edit button label                  |
+| saveButtonLabel   | React.ReactNode                      | No       | "Save"   | Custom save button label                  |
+| showIcons         | boolean                              | No       | false    | Toggle button icons visibility            |
+| iconsOnly         | boolean                              | No       | false    | Show only icons without text labels       |
+| editIcon          | React.ElementType                    | No       | LuPencil | Custom edit icon component                |
+| saveIcon          | React.ElementType                    | No       | LuCheck  | Custom save icon component                |
+| iconPosition      | "left" \| "right"                    | No       | "left"   | Position of icons in buttons              |
+| onEditButtonClick | () => void                           | No       | () => {} | Callback when edit button is clicked      |
+| onSaveButtonClick | () => void                           | No       | () => {} | Callback when save button is clicked      |
 
-The component extends `React.InputHTMLAttributes<HTMLInputElement>`, inheriting all native input attributes while preserving special handling for `value`, `defaultValue`, `type`, and `onChange` props.
+\*Either `value` + `onChange` (controlled) or `defaultValue` (uncontrolled) must be provided.
 
 ## 💡 Examples
 

--- a/README.md
+++ b/README.md
@@ -44,24 +44,24 @@ function App() {
 
 ## 🔧 Props
 
-| Prop              | Type                                 | Required | Default  | Description                               |
-| ----------------- | ------------------------------------ | -------- | -------- | ----------------------------------------- |
-| value             | string                               | Yes\*    | -        | Controlled text value to display and edit |
-| defaultValue      | string                               | No       | -        | Initial uncontrolled value                |
-| type              | string                               | No       | "text"   | HTML input type attribute                 |
-| onChange          | ChangeEventHandler<HTMLInputElement> | Yes\*    | -        | HTML input onChange handler               |
-| isEditing         | boolean                              | No       | false    | Control the editing state                 |
-| label             | string                               | No       | ""       | Label for the input field                 |
-| className         | string                               | No       | ""       | Container class name                      |
-| editButtonLabel   | React.ReactNode                      | No       | "Edit"   | Custom edit button label                  |
-| saveButtonLabel   | React.ReactNode                      | No       | "Save"   | Custom save button label                  |
-| showIcons         | boolean                              | No       | false    | Toggle button icons visibility            |
-| iconsOnly         | boolean                              | No       | false    | Show only icons without text labels       |
-| editIcon          | React.ElementType                    | No       | LuPencil | Custom edit icon component                |
-| saveIcon          | React.ElementType                    | No       | LuCheck  | Custom save icon component                |
-| iconPosition      | "left" \| "right"                    | No       | "left"   | Position of icons in buttons              |
-| onEditButtonClick | () => void                           | No       | () => {} | Callback when edit button is clicked      |
-| onSaveButtonClick | () => void                           | No       | () => {} | Callback when save button is clicked      |
+| Prop              | Type                                   | Required | Default  | Description                               |
+| ----------------- | -------------------------------------- | -------- | -------- | ----------------------------------------- |
+| value             | string                                 | Yes\*    | -        | Controlled text value to display and edit |
+| defaultValue      | string                                 | No       | -        | Initial uncontrolled value                |
+| type              | string                                 | No       | "text"   | HTML input type attribute                 |
+| onChange          | `ChangeEventHandler<HTMLInputElement>` | Yes\*    | -        | HTML input onChange handler               |
+| isEditing         | boolean                                | No       | false    | Control the editing state                 |
+| label             | string                                 | No       | ""       | Label for the input field                 |
+| className         | string                                 | No       | ""       | Container class name                      |
+| editButtonLabel   | React.ReactNode                        | No       | "Edit"   | Custom edit button label                  |
+| saveButtonLabel   | React.ReactNode                        | No       | "Save"   | Custom save button label                  |
+| showIcons         | boolean                                | No       | false    | Toggle button icons visibility            |
+| iconsOnly         | boolean                                | No       | false    | Show only icons without text labels       |
+| editIcon          | React.ElementType                      | No       | LuPencil | Custom edit icon component                |
+| saveIcon          | React.ElementType                      | No       | LuCheck  | Custom save icon component                |
+| iconPosition      | "left" \| "right"                      | No       | "left"   | Position of icons in buttons              |
+| onEditButtonClick | () => void                             | No       | () => {} | Callback when edit button is clicked      |
+| onSaveButtonClick | () => void                             | No       | () => {} | Callback when save button is clicked      |
 
 \*Either `value` + `onChange` (controlled) or `defaultValue` (uncontrolled) must be provided.
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ function FormExample() {
 ### Register Example
 
 ```tsx
-import { useForm, Controller } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { InputClickEdit } from "@nobrainers/react-click-edit";
 
 function RegisterExample() {

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 https://github.com/user-attachments/assets/58c8cca5-878a-4e64-aa06-a8e202318f2a
 
-
 > A lightweight, easy-to-use React component that makes any text editable with a click!
 
 ## ✨ Features
@@ -47,8 +46,9 @@ function App() {
 
 | Prop                 | Type                    | Default  | Description                                 |
 | -------------------- | ----------------------- | -------- | ------------------------------------------- |
-| value                | string                  | ""       | Text to display and edit                    |
-| isEditing            | boolean                 | false    | Initial editing state                       |
+| value                | string                  | ""       | Controlled text value to display and edit   |
+| defaultValue         | string                  | ""       | Initial uncontrolled value                  |
+| isEditing            | boolean                 | false    | Control the editing state                   |
 | inputType            | string                  | "text"   | HTML input type (text, number, email, etc.) |
 | label                | string                  | ""       | Label for the input field                   |
 | className            | string                  | ""       | Container class name                        |
@@ -66,6 +66,8 @@ function App() {
 | onEditButtonClick    | () => void              | () => {} | Callback when edit button is clicked        |
 | onInputChange        | (value: string) => void | () => {} | Callback when input value changes           |
 | onSaveButtonClick    | () => void              | () => {} | Callback when save button is clicked        |
+
+The component also accepts all standard HTML input attributes except for `value`, `defaultValue`, `onChange`, and `type`.
 
 ## 💡 Examples
 
@@ -149,6 +151,32 @@ function ControlledExample() {
   editIcon={FiEdit}
   saveIcon={FiSave}
 />
+```
+
+### React Hook Form Integration
+
+```tsx
+import { useForm, Controller } from "react-hook-form";
+import { InputClickEdit } from "@nobrainers/react-click-edit";
+
+function FormExample() {
+  const { control, handleSubmit } = useForm();
+  const onSubmit = (data) => console.log(data);
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Controller
+        name="editableText"
+        control={control}
+        defaultValue="Edit me"
+        render={({ field }) => (
+          <InputClickEdit {...field} onInputChange={field.onChange} />
+        )}
+      />
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
 ```
 
 ## 🎨 Styling

--- a/README.md
+++ b/README.md
@@ -38,36 +38,32 @@ import { InputClickEdit } from "@nobrainers/react-click-edit";
 function App() {
   const [name, setName] = useState("John Doe");
 
-  return <InputClickEdit value={name} onInputChange={setName} />;
+  return <InputClickEdit value={name} onChange={setName} />;
 }
 ```
 
 ## 🔧 Props
 
-| Prop                 | Type                    | Default  | Description                                 |
-| -------------------- | ----------------------- | -------- | ------------------------------------------- |
-| value                | string                  | ""       | Controlled text value to display and edit   |
-| defaultValue         | string                  | ""       | Initial uncontrolled value                  |
-| isEditing            | boolean                 | false    | Control the editing state                   |
-| inputType            | string                  | "text"   | HTML input type (text, number, email, etc.) |
-| label                | string                  | ""       | Label for the input field                   |
-| className            | string                  | ""       | Container class name                        |
-| inputClassName       | string                  | ""       | Input field class name                      |
-| editButtonClassName  | string                  | ""       | Edit button class name                      |
-| saveButtonClassName  | string                  | ""       | Save button class name                      |
-| editWrapperClassName | string                  | ""       | Edit mode wrapper class name                |
-| saveButtonLabel      | React.ReactNode         | "Save"   | Custom save button label                    |
-| editButtonLabel      | React.ReactNode         | "Edit"   | Custom edit button label                    |
-| showIcons            | boolean                 | false    | Toggle button icons visibility              |
-| iconsOnly            | boolean                 | false    | Show only icons without text labels         |
-| editIcon             | React.ElementType       | LuPencil | Custom edit icon component                  |
-| saveIcon             | React.ElementType       | LuCheck  | Custom save icon component                  |
-| iconPosition         | "left" \| "right"       | "left"   | Position of icons in buttons                |
-| onEditButtonClick    | () => void              | () => {} | Callback when edit button is clicked        |
-| onInputChange        | (value: string) => void | () => {} | Callback when input value changes           |
-| onSaveButtonClick    | () => void              | () => {} | Callback when save button is clicked        |
+| Prop              | Type                                 | Default  | Description                               |
+| ----------------- | ------------------------------------ | -------- | ----------------------------------------- |
+| value             | string                               | -        | Controlled text value to display and edit |
+| defaultValue      | string                               | -        | Initial uncontrolled value                |
+| type              | string                               | "text"   | HTML input type attribute                 |
+| onChange          | ChangeEventHandler<HTMLInputElement> | -        | HTML input onChange handler               |
+| isEditing         | boolean                              | false    | Control the editing state                 |
+| label             | string                               | ""       | Label for the input field                 |
+| className         | string                               | ""       | Container class name                      |
+| editButtonLabel   | React.ReactNode                      | "Edit"   | Custom edit button label                  |
+| saveButtonLabel   | React.ReactNode                      | "Save"   | Custom save button label                  |
+| showIcons         | boolean                              | false    | Toggle button icons visibility            |
+| iconsOnly         | boolean                              | false    | Show only icons without text labels       |
+| editIcon          | React.ElementType                    | LuPencil | Custom edit icon component                |
+| saveIcon          | React.ElementType                    | LuCheck  | Custom save icon component                |
+| iconPosition      | "left" \| "right"                    | "left"   | Position of icons in buttons              |
+| onEditButtonClick | () => void                           | () => {} | Callback when edit button is clicked      |
+| onSaveButtonClick | () => void                           | () => {} | Callback when save button is clicked      |
 
-The component also accepts all standard HTML input attributes except for `value`, `defaultValue`, `onChange`, and `type`.
+The component extends `React.InputHTMLAttributes<HTMLInputElement>`, inheriting all native input attributes while preserving special handling for `value`, `defaultValue`, `type`, and `onChange` props.
 
 ## 💡 Examples
 
@@ -76,7 +72,7 @@ The component also accepts all standard HTML input attributes except for `value`
 ```tsx
 function BasicExample() {
   const [name, setName] = useState("John Doe");
-  return <InputClickEdit value={name} onInputChange={setName} />;
+  return <InputClickEdit value={name} onChange={setName} />;
 }
 ```
 
@@ -85,9 +81,9 @@ function BasicExample() {
 ```tsx
 <InputClickEdit
   label="Age"
-  inputType="number"
+  type="number"
   value="25"
-  onInputChange={(value) => console.log(value)}
+  onChange={(value) => console.log(value)}
 />
 ```
 
@@ -135,7 +131,7 @@ function ControlledExample() {
       isEditing={isEditing}
       onEditButtonClick={() => setIsEditing(true)}
       onSaveButtonClick={() => setIsEditing(false)}
-      onInputChange={setValue}
+      onChange={setValue}
     />
   );
 }
@@ -170,9 +166,28 @@ function FormExample() {
         control={control}
         defaultValue="Edit me"
         render={({ field }) => (
-          <InputClickEdit {...field} onInputChange={field.onChange} />
+          <InputClickEdit {...field} onChange={field.onChange} />
         )}
       />
+      <button type="submit">Submit</button>
+    </form>
+  );
+}
+```
+
+### Register Example
+
+```tsx
+import { useForm, Controller } from "react-hook-form";
+import { InputClickEdit } from "@nobrainers/react-click-edit";
+
+function RegisterExample() {
+  const { register, handleSubmit } = useForm();
+  const onSubmit = (data) => console.log(data);
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <InputClickEdit {...register("editableText")} />
       <button type="submit">Submit</button>
     </form>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "jsdom": "^26.0.0",
         "lint-staged": "^15.3.0",
         "prettier": "^3.4.2",
+        "react-hook-form": "^7.54.2",
         "semantic-release": "^24.2.1",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0",
@@ -12746,6 +12747,22 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.54.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
+      "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "jsdom": "^26.0.0",
     "lint-staged": "^15.3.0",
     "prettier": "^3.4.2",
+    "react-hook-form": "^7.54.2",
     "semantic-release": "^24.2.1",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0",

--- a/src/InputClickEdit/InputClickEdit.test.tsx
+++ b/src/InputClickEdit/InputClickEdit.test.tsx
@@ -55,12 +55,16 @@ describe("InputClickEdit", () => {
     });
 
     it("should call onInputChange when input value changes", () => {
-      const onInputChange = vi.fn();
-      render(<InputClickEdit isEditing onInputChange={onInputChange} />);
-      fireEvent.change(screen.getByRole("textbox"), {
-        target: { value: "New Value" },
-      });
-      expect(onInputChange).toHaveBeenCalledWith("New Value");
+      const onChange = vi.fn();
+      const mockEventChange = { target: { value: "New Value" } };
+      render(<InputClickEdit isEditing onChange={onChange} />);
+      fireEvent.change(screen.getByRole("textbox"), mockEventChange);
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: expect.objectContaining({ value: "New Value" }),
+        })
+      );
     });
 
     it("should call onSaveButtonClick when save button is clicked", () => {
@@ -133,7 +137,7 @@ describe("InputClickEdit", () => {
 
   describe("Input Types", () => {
     it("should render different input types", () => {
-      render(<InputClickEdit isEditing inputType="number" />);
+      render(<InputClickEdit isEditing type="number" />);
       expect(screen.getByRole("spinbutton")).toBeInTheDocument();
     });
   });

--- a/src/InputClickEdit/InputClickEdit.tsx
+++ b/src/InputClickEdit/InputClickEdit.tsx
@@ -12,24 +12,17 @@ type InputClickEditProps = {
   editButtonClassName?: string;
   saveButtonClassName?: string;
   editWrapperClassName?: string;
-  value?: string;
-  defaultValue?: string;
   saveButtonLabel?: React.ReactNode;
   editButtonLabel?: React.ReactNode;
   label?: string;
-  inputType?: string;
   showIcons?: boolean;
   editIcon?: React.ElementType;
   saveIcon?: React.ElementType;
   iconPosition?: "left" | "right";
   iconsOnly?: boolean;
   onEditButtonClick?: () => void;
-  onInputChange?: (value: string) => void;
   onSaveButtonClick?: () => void;
-} & Omit<
-  React.InputHTMLAttributes<HTMLInputElement>,
-  "value" | "defaultValue" | "onChange" | "type"
->;
+} & React.InputHTMLAttributes<HTMLInputElement>;
 
 const InputClickEdit = forwardRef<HTMLInputElement, InputClickEditProps>(
   (
@@ -40,8 +33,8 @@ const InputClickEdit = forwardRef<HTMLInputElement, InputClickEditProps>(
       saveButtonClassName = "",
       editWrapperClassName = "",
       value,
-      defaultValue = "",
-      inputType = "text",
+      defaultValue,
+      type = "text",
       isEditing = false,
       saveButtonLabel = "Save",
       editButtonLabel = "Edit",
@@ -52,7 +45,7 @@ const InputClickEdit = forwardRef<HTMLInputElement, InputClickEditProps>(
       iconsOnly = false,
       iconPosition = "left",
       onEditButtonClick = () => {},
-      onInputChange = () => {},
+      onChange,
       onSaveButtonClick = () => {},
       ...rest
     },
@@ -77,12 +70,12 @@ const InputClickEdit = forwardRef<HTMLInputElement, InputClickEditProps>(
       onEditButtonClick?.();
     };
 
-    const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = e.target.value;
       if (!isControlled) {
         setInternalValue(newValue);
       }
-      onInputChange?.(newValue);
+      onChange?.(e);
     };
 
     const handleSave = () => {
@@ -92,9 +85,9 @@ const InputClickEdit = forwardRef<HTMLInputElement, InputClickEditProps>(
 
     const inputProps = {
       className: cn(styles.input, inputClassName),
-      onChange,
+      onChange: handleChange,
       value: isControlled ? value : internalValue,
-      type: inputType,
+      type,
       ref,
       ...rest,
     };

--- a/src/InputClickEdit/InputClickEdit.tsx
+++ b/src/InputClickEdit/InputClickEdit.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, forwardRef } from "react";
+import { useState, useEffect, forwardRef, useCallback } from "react";
 import { LuPencil } from "react-icons/lu";
 import { LuCheck } from "react-icons/lu";
 import cn from "classnames";
@@ -52,7 +52,9 @@ const InputClickEdit = forwardRef<HTMLInputElement, InputClickEditProps>(
     ref
   ) => {
     const [editing, setEditing] = useState<boolean>(isEditing);
-    const [internalValue, setInternalValue] = useState(value ?? defaultValue);
+    const [internalValue, setInternalValue] = useState(
+      () => value ?? defaultValue
+    );
     const isControlled = value !== undefined;
 
     useEffect(() => {
@@ -65,23 +67,26 @@ const InputClickEdit = forwardRef<HTMLInputElement, InputClickEditProps>(
       }
     }, [value, isControlled]);
 
-    const onEditClick = () => {
+    const onEditClick = useCallback(() => {
       setEditing(true);
       onEditButtonClick?.();
-    };
+    }, [onEditButtonClick]);
 
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const newValue = e.target.value;
-      if (!isControlled) {
-        setInternalValue(newValue);
-      }
-      onChange?.(e);
-    };
+    const handleChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        const newValue = e.target.value;
+        if (!isControlled) {
+          setInternalValue(newValue);
+        }
+        onChange?.(e);
+      },
+      [onChange, isControlled]
+    );
 
-    const handleSave = () => {
+    const handleSave = useCallback(() => {
       setEditing(false);
       onSaveButtonClick?.();
-    };
+    }, [onSaveButtonClick]);
 
     const inputProps = {
       className: cn(styles.input, inputClassName),
@@ -116,6 +121,8 @@ const InputClickEdit = forwardRef<HTMLInputElement, InputClickEditProps>(
               className={cn(buttonBaseClassName, saveButtonClassName)}
               onClick={handleSave}
               aria-label={iconsOnly ? saveButtonLabel?.toString() : undefined}
+              type="button"
+              aria-pressed={editing}
             >
               {(showIcons || iconsOnly) && <SaveIcon data-testid="save-icon" />}
               {!iconsOnly && saveButtonLabel}
@@ -129,6 +136,8 @@ const InputClickEdit = forwardRef<HTMLInputElement, InputClickEditProps>(
               className={cn(buttonBaseClassName, editButtonClassName)}
               onClick={onEditClick}
               aria-label={iconsOnly ? editButtonLabel?.toString() : undefined}
+              type="button"
+              aria-pressed={!editing}
             >
               {(showIcons || iconsOnly) && <EditIcon data-testid="edit-icon" />}
               {!iconsOnly && editButtonLabel}


### PR DESCRIPTION
This PR adds the feature of whether the component controlled or not and can be integrated easily with react-hook-form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for uncontrolled input mode with `defaultValue`
  - Enhanced component compatibility with React Hook Form
  - Improved ref handling for input elements

- **Documentation**
  - Updated README with detailed prop descriptions and usage examples
  - Reformatted props table for clarity and marked required fields

- **Dependencies**
  - Added `react-hook-form` library for form management

- **Testing**
  - Expanded test coverage for controlled and uncontrolled modes
  - Added compatibility tests for React Hook Form integration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->